### PR TITLE
Removed custom trait and added file_id

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use rand::Rng;
 use rust_bit_cask_db::parse_key_value_from_buffer;
 use rust_bit_cask_db::parse_key_value_from_reader;
 use std::collections::HashMap;
+use std::path::Path;
 use std::path::PathBuf;
 use std::{
     collections::BTreeMap,
@@ -23,18 +24,81 @@ struct IndexEntry {
 struct SStStorage<T: Read + Write + Seek> {
     index: BTreeMap<Vec<u8>, IndexEntry>,
     file: T,
+    active_file_id: u32,
     file_paths: HashMap<u32, PathBuf>
 }
 
-impl<T: Read + Write + Seek> SStStorage<T> {
-    fn new(file: T, file_id: u32, path: PathBuf) -> Self {
+trait Storage: Read + Write + Seek {
+    fn open(path: &str) -> Result<Self, Error> where Self: Sized;
+}
+
+impl Storage for File {
+    fn open(path: &str) -> Result<Self, Error> {
+        open_file_read_write(path)
+    }
+}
+
+impl<T: Storage> SStStorage<T> {
+    fn new(file: T, file_id: u32, path: PathBuf, active_file_id: u32) -> Self {
         let mut file_paths = HashMap::new();
         file_paths.insert(file_id, path);
         SStStorage {
             index: BTreeMap::new(),
             file,
+            active_file_id,
             file_paths,
         }
+    }
+
+    fn open(dir: &Path) -> Result<Self, Error> {
+        let paths =  match list_directory_paths(dir) {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("Error reading directory: {}", e);
+                return Err(e.into());
+            }
+        };
+            
+        let mut file_ids_and_name = paths.iter().filter_map(|item| {
+            let file_ids: u32 = item.file_stem()?.to_str()?.parse().ok()?;
+            Some((file_ids, item.to_str()?.to_string()))       
+        }).collect::<Vec<(u32, String)>>();
+        file_ids_and_name.sort();
+        let (file_id, name) = match file_ids_and_name.last() {
+            Some((id, name)) => (*id, name.clone()),
+            None => (0, format!("{}/0.log", dir.to_str().unwrap_or("bitcask/active"))),
+        };
+
+        let file = T::open(&name)?;
+        let mut file_paths = HashMap::new();
+        for (id, path) in file_ids_and_name {
+            file_paths.insert(id, PathBuf::from(path));
+        }
+
+        // Adding this explicit line to add 0.log when it doesn't exist in the HasMap
+        file_paths.insert(file_id, PathBuf::from(&name));
+        
+        let mut storage = SStStorage {
+            index: BTreeMap::new(),
+            file,
+            active_file_id: file_id,
+            file_paths,
+        };
+        storage.load_db_from_disk()?;
+        Ok(storage)
+    }
+
+    fn rotate_file(&mut self) -> Result<(), Error> {
+        self.file.flush()?;
+        // Logic to rotate the file when max size is reached
+        let updated_active_file_id = self.active_file_id + 1;
+        let new_file_name = format!("bitcask/active/{}.log", updated_active_file_id);
+        let new_file = T::open(&new_file_name)?;
+        self.active_file_id = updated_active_file_id;
+        self.file_paths
+            .insert(updated_active_file_id, PathBuf::from(new_file_name));
+        self.file = new_file;
+        Ok(())
     }
 
     fn insert_key(&mut self, key: Vec<u8>, value: IndexEntry) {
@@ -51,16 +115,25 @@ impl<T: Read + Write + Seek> SStStorage<T> {
         let kv = KeyValue::new(key, value, timestamp, mark_as_deleted, 0);
 
         let buffer = kv.to_buffer();
-        let offset = self.file.seek(SeekFrom::End(0))?;
+        let current_offset = self.file.seek(SeekFrom::End(0))?;
         let length = buffer.len() as u64;
+        
+        const MAX_FILE_SIZE: u64 = 1024 * 1024;
+        if current_offset + length > MAX_FILE_SIZE {
+            // Logic to handle file rotation can be added here.
+            // For simplicity, we will just print a message.
+            println!("Max file size reached. File rotation logic should be implemented.");
+            self.rotate_file()?;
+        }
         self.file.write(&buffer)?;
+        
         // Only update the in-memory index for new or updated keys, not for deletions.
         if !mark_as_deleted {
             self.insert_key(
                 key.to_vec(),
                 IndexEntry {
-                    file_id: 0,
-                    offset,
+                    file_id: self.active_file_id,
+                    offset: current_offset,
                     length,
                     timestamp,
                 },
@@ -113,7 +186,7 @@ impl<T: Read + Write + Seek> SStStorage<T> {
         Ok(())
     }
 
-    fn load_db_from_disk(&mut self) -> Result<(), Box<dyn std::error::Error>>
+    fn load_db_from_disk(&mut self) -> Result<(), io::Error>
     where
         T: std::io::Read,
     {
@@ -142,7 +215,7 @@ impl<T: Read + Write + Seek> SStStorage<T> {
                         self.index.insert(
                             kv.key,
                             IndexEntry {
-                                file_id: 0,
+                                file_id: self.active_file_id,
                                 offset: record_start_offset,
                                 length: record_len,
                                 timestamp: kv.timestamp,
@@ -158,7 +231,7 @@ impl<T: Read + Write + Seek> SStStorage<T> {
                 Err(e) => {
                     // An actual error occurred.
                     eprintln!("Error reading log file during startup: {}", e);
-                    return Err(Box::new(e));
+                    return Err(e);
                 }
             }
         }
@@ -269,22 +342,27 @@ impl<T: Read + Write + Seek> SStStorage<T> {
     }
 }
 
+fn list_directory_paths(path: &Path) -> io::Result<Vec<PathBuf>> {
+    let mut all_paths = Vec::new();
+    if path.is_dir() {
+        for entry in fs::read_dir(path)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) == Some("log") {
+                // print!("Found log file: {:?}\n", path);
+                all_paths.push(path);
+            }
+        }
+    }
+    all_paths.sort();
+    Ok(all_paths)
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Hello, welcome to DB created on BitCask paper!...................");
     fs::create_dir_all("bitcask/active")?;
-    let name = "bitcask/active/database.txt";
-    let file = match open_file_read_write(&name) {
-        Ok(mut file) => {
-            // Print initial offset
-            let initial_offset = file.seek(SeekFrom::End(0))?;
-            println!("Initial offset after opening: {}", initial_offset);
-            file
-        }
-        Err(err) => return Err(err.into()),
-    };
-    let mut sst_storage = SStStorage::new(file, 0, PathBuf::from(name));
-    // Load data from filesystem into BTree Map which acts as an in-memory.
-    sst_storage.load_db_from_disk()?;
+
+    let mut sst_storage: SStStorage<File> = SStStorage::open(Path::new("bitcask/active"))?;
 
     let mut last_cleanup_time = Instant::now();
 
@@ -360,8 +438,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let mut rng = rand::thread_rng(); // Initialize the random number generator
                 let start_write = Instant::now();
                 let mut total_write_time = Duration::new(0, 0);
-                for _ in 0..1000 {
-                    let key_string = rng.gen_range(1..=1000).to_string().to_string();
+                for _ in 0..50000 {
+                    let key_string = rng.gen_range(1..=50000).to_string().to_string();
                     let key = key_string.as_bytes();
                     let value_string = (3 * key[0] as u64).to_string();
                     let value = value_string.as_bytes();
@@ -438,7 +516,7 @@ fn test_timestamp_issue() -> Result<(), Box<dyn std::error::Error>> {
     let test_timestamp = Some(1749763021u64);
 
     let file = std::fs::File::create("test_timestamp.db")?;
-    let storage = SStStorage::new(file, 0, PathBuf::from("test_timestamp.db"));
+    let storage = SStStorage::new(file, 0, PathBuf::from("test_timestamp.db"), 0);
 
     storage.test_timestamp_serialization(test_timestamp)?;
 
@@ -461,7 +539,7 @@ fn test_corruption() -> Result<(), Box<dyn std::error::Error>> {
     {
         println!("Step 1: Writing a known record to '{}'...", test_file_name);
         let file = open_file_read_write(test_file_name)?;
-        let mut sst_storage = SStStorage::new(file, 0, PathBuf::from(test_file_name));
+        let mut sst_storage = SStStorage::new(file, 0, PathBuf::from(test_file_name), 0);
         let key = b"integrity_check";
         let value = b"this_data_is_good";
         sst_storage.write(key, value, false, None)?;
@@ -487,7 +565,7 @@ fn test_corruption() -> Result<(), Box<dyn std::error::Error>> {
     // --- Step 3 & 4: Attempt to load the corrupted file and observe ---
     println!("Step 3: Attempting to load the corrupted database...");
     let file = open_file_read_write(test_file_name)?;
-    let mut sst_storage = SStStorage::new(file, 0, PathBuf::from(test_file_name));
+    let mut sst_storage = SStStorage::new(file, 0, PathBuf::from(test_file_name), 0);
 
     // The load_db_from_disk() function will read all records and verify checksums.
     // This call is EXPECTED to fail.

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,8 @@ use dance_of_bytes::{self, KeyValue};
 use rand::Rng;
 use rust_bit_cask_db::parse_key_value_from_buffer;
 use rust_bit_cask_db::parse_key_value_from_reader;
+use std::collections::HashMap;
+use std::path::PathBuf;
 use std::{
     collections::BTreeMap,
     fs::{self, File, OpenOptions},
@@ -12,41 +14,26 @@ use std::{
 mod main_test;
 
 struct IndexEntry {
+    file_id: u32,
     offset: u64,
     length: u64,
     timestamp: Option<u64>,
 }
 
-struct SStStorage<T: FileIO> {
+struct SStStorage<T: Read + Write + Seek> {
     index: BTreeMap<Vec<u8>, IndexEntry>,
     file: T,
+    file_paths: HashMap<u32, PathBuf>
 }
 
-trait FileIO {
-    fn write(&mut self, buf: &[u8]) -> io::Result<()>;
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<()>;
-    fn seek_from(&mut self, pos: SeekFrom) -> io::Result<u64>;
-}
-
-impl FileIO for File {
-    fn write(&mut self, buf: &[u8]) -> io::Result<()> {
-        File::write_all(self, buf)
-    }
-
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<()> {
-        File::read_exact(self, buf)
-    }
-
-    fn seek_from(&mut self, pos: SeekFrom) -> io::Result<u64> {
-        File::seek(self, pos)
-    }
-}
-
-impl<T: FileIO> SStStorage<T> {
-    fn new(file: T) -> Self {
+impl<T: Read + Write + Seek> SStStorage<T> {
+    fn new(file: T, file_id: u32, path: PathBuf) -> Self {
+        let mut file_paths = HashMap::new();
+        file_paths.insert(file_id, path);
         SStStorage {
             index: BTreeMap::new(),
             file,
+            file_paths,
         }
     }
 
@@ -64,7 +51,7 @@ impl<T: FileIO> SStStorage<T> {
         let kv = KeyValue::new(key, value, timestamp, mark_as_deleted, 0);
 
         let buffer = kv.to_buffer();
-        let offset = self.file.seek_from(SeekFrom::End(0))?;
+        let offset = self.file.seek(SeekFrom::End(0))?;
         let length = buffer.len() as u64;
         self.file.write(&buffer)?;
         // Only update the in-memory index for new or updated keys, not for deletions.
@@ -72,6 +59,7 @@ impl<T: FileIO> SStStorage<T> {
             self.insert_key(
                 key.to_vec(),
                 IndexEntry {
+                    file_id: 0,
                     offset,
                     length,
                     timestamp,
@@ -83,10 +71,13 @@ impl<T: FileIO> SStStorage<T> {
 
     fn read(&mut self, key: &[u8]) -> Result<Option<Vec<u8>>, Error> {
         if let Some(index_entry) = self.index.get(key) {
+            println!("{:?}", self.file_paths);
+            let path = self.file_paths.get(&index_entry.file_id)
+                .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "File path not found"))?;
+            let mut file = File::open(path)?;
             let mut buffer = vec![0; index_entry.length as usize];
-            self.file
-                .seek_from(io::SeekFrom::Start(index_entry.offset))?;
-            self.file.read(&mut buffer)?;
+            file.seek(io::SeekFrom::Start(index_entry.offset))?;
+            file.read(&mut buffer)?;
             let kv = parse_key_value_from_buffer(&buffer)?;
             Ok(Some(kv.value))
         } else {
@@ -127,9 +118,9 @@ impl<T: FileIO> SStStorage<T> {
         T: std::io::Read,
     {
         // Seek to the beginning of the active database file to read all entries.
-        let mut current_offset = self.file.seek_from(SeekFrom::Start(0))?;
-        let file_size = self.file.seek_from(SeekFrom::End(0))?;
-        self.file.seek_from(SeekFrom::Start(0))?; // Seek back to start for reading.
+        let mut current_offset = self.file.seek(SeekFrom::Start(0))?;
+        let file_size = self.file.seek(SeekFrom::End(0))?;
+        self.file.seek(SeekFrom::Start(0))?; // Seek back to start for reading.
 
         self.index.clear(); // Rebuilding from scratch.
 
@@ -151,6 +142,7 @@ impl<T: FileIO> SStStorage<T> {
                         self.index.insert(
                             kv.key,
                             IndexEntry {
+                                file_id: 0,
                                 offset: record_start_offset,
                                 length: record_len,
                                 timestamp: kv.timestamp,
@@ -173,7 +165,7 @@ impl<T: FileIO> SStStorage<T> {
 
         // After reading the log, the file cursor must be at the end
         // so that new writes are appended correctly.
-        self.file.seek_from(SeekFrom::End(0))?;
+        self.file.seek(SeekFrom::End(0))?;
         Ok(())
     }
 
@@ -290,7 +282,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         Err(err) => return Err(err.into()),
     };
-    let mut sst_storage = SStStorage::new(file);
+    let mut sst_storage = SStStorage::new(file, 0, PathBuf::from(name));
     // Load data from filesystem into BTree Map which acts as an in-memory.
     sst_storage.load_db_from_disk()?;
 
@@ -446,7 +438,7 @@ fn test_timestamp_issue() -> Result<(), Box<dyn std::error::Error>> {
     let test_timestamp = Some(1749763021u64);
 
     let file = std::fs::File::create("test_timestamp.db")?;
-    let storage = SStStorage::new(file);
+    let storage = SStStorage::new(file, 0, PathBuf::from("test_timestamp.db"));
 
     storage.test_timestamp_serialization(test_timestamp)?;
 
@@ -469,7 +461,7 @@ fn test_corruption() -> Result<(), Box<dyn std::error::Error>> {
     {
         println!("Step 1: Writing a known record to '{}'...", test_file_name);
         let file = open_file_read_write(test_file_name)?;
-        let mut sst_storage = SStStorage::new(file);
+        let mut sst_storage = SStStorage::new(file, 0, PathBuf::from(test_file_name));
         let key = b"integrity_check";
         let value = b"this_data_is_good";
         sst_storage.write(key, value, false, None)?;
@@ -495,7 +487,7 @@ fn test_corruption() -> Result<(), Box<dyn std::error::Error>> {
     // --- Step 3 & 4: Attempt to load the corrupted file and observe ---
     println!("Step 3: Attempting to load the corrupted database...");
     let file = open_file_read_write(test_file_name)?;
-    let mut sst_storage = SStStorage::new(file);
+    let mut sst_storage = SStStorage::new(file, 0, PathBuf::from(test_file_name));
 
     // The load_db_from_disk() function will read all records and verify checksums.
     // This call is EXPECTED to fail.

--- a/src/main_test.rs
+++ b/src/main_test.rs
@@ -12,7 +12,7 @@ mod tests {
         // Clean up any existing file from previous test runs
         let _ = fs::remove_file(temp_file_path);
         let file = open_file_read_write(temp_file_path).expect("Failed to create temp file");
-        let mut sst_storage = SStStorage::new(file);
+        let mut sst_storage = SStStorage::new(file, 0, std::path::PathBuf::from(temp_file_path));
 
         let key = b"some_key".to_vec();
         let value = b"some_value".to_vec();
@@ -37,7 +37,7 @@ mod tests {
         let temp_file_path = "temp_test_file_insert_and_delete.txt";
         let _ = fs::remove_file(temp_file_path);
         let file = open_file_read_write(temp_file_path).expect("Failed to create temp file");
-        let mut sst_storage = SStStorage::new(file);
+        let mut sst_storage = SStStorage::new(file, 0, std::path::PathBuf::from(temp_file_path));
 
         let key = b"my_key".to_vec();
         let value = b"my_value".to_vec();
@@ -59,7 +59,7 @@ mod tests {
         let temp_file_path = "temp_test_file_insert_delete_non_existing.txt";
         let _ = fs::remove_file(temp_file_path);
         let file = open_file_read_write(temp_file_path).expect("Failed to create temp file");
-        let mut sst_storage = SStStorage::new(file);
+        let mut sst_storage = SStStorage::new(file, 0, std::path::PathBuf::from(temp_file_path));
 
         let key = b"my_key".to_vec();
         let value = b"my_value".to_vec();
@@ -82,7 +82,7 @@ mod tests {
         let temp_file_path = "temp_test_file_update_key.txt";
         let _ = fs::remove_file(temp_file_path);
         let file = open_file_read_write(temp_file_path).expect("Failed to create temp file");
-        let mut sst_storage = SStStorage::new(file);
+        let mut sst_storage = SStStorage::new(file, 0, std::path::PathBuf::from(temp_file_path));
 
         // Insert a known kv pair to the file
         let key = b"my_key".to_vec();
@@ -111,7 +111,7 @@ mod tests {
         let temp_file_path = "temp_test_file_delete_existing.txt";
         let _ = fs::remove_file(temp_file_path);
         let file = open_file_read_write(temp_file_path).expect("Failed to create temp file");
-        let mut sst_storage = SStStorage::new(file);
+        let mut sst_storage = SStStorage::new(file, 0, std::path::PathBuf::from(temp_file_path));
 
         // Insert a known kv pair to the file
         let key = b"my_key".to_vec();
@@ -146,7 +146,7 @@ mod tests {
         let temp_file_path = "temp_test_file_delete_non_existing.txt";
         let _ = fs::remove_file(temp_file_path);
         let file = open_file_read_write(temp_file_path).expect("Failed to create temp file");
-        let mut sst_storage = SStStorage::new(file);
+        let mut sst_storage = SStStorage::new(file, 0, std::path::PathBuf::from(temp_file_path));
 
         // Try to delete a key that was never inserted
         let non_existent_key = b"ghost_key".to_vec();

--- a/src/main_test.rs
+++ b/src/main_test.rs
@@ -1,18 +1,16 @@
 #[cfg(test)]
 mod tests {
-    use std::fs;
+    use std::{fs::{self, File}, path::Path};
 
     use dance_of_bytes::read_from_file;
 
-    use crate::{open_file_read_write, SStStorage};
+    use crate::SStStorage;
     #[test]
     fn test_write() {
         // Create a temporary file for testing
-        let temp_file_path = "temp_test_file_write.txt";
-        // Clean up any existing file from previous test runs
-        let _ = fs::remove_file(temp_file_path);
-        let file = open_file_read_write(temp_file_path).expect("Failed to create temp file");
-        let mut sst_storage = SStStorage::new(file, 0, std::path::PathBuf::from(temp_file_path));
+        let temp_dir_path = "temp_test_dir_write";
+        fs::create_dir_all(temp_dir_path).expect("Failed to create temp dir");
+        let mut sst_storage:SStStorage<File> = SStStorage::open(Path::new(&temp_dir_path)).expect("Failed to open SStStorage");
 
         let key = b"some_key".to_vec();
         let value = b"some_value".to_vec();
@@ -28,16 +26,15 @@ mod tests {
         assert_eq!(record_value, Some(value));
 
         // Clean up the temporary file
-        fs::remove_file(temp_file_path).expect("Failed to remove temp file");
+        fs::remove_dir_all(temp_dir_path).expect("Failed to remove temp file");
     }
 
     #[test]
     fn test_insert_key_and_read_existing_key() {
         // Create a temporary file for testing
-        let temp_file_path = "temp_test_file_insert_and_delete.txt";
-        let _ = fs::remove_file(temp_file_path);
-        let file = open_file_read_write(temp_file_path).expect("Failed to create temp file");
-        let mut sst_storage = SStStorage::new(file, 0, std::path::PathBuf::from(temp_file_path));
+         let temp_dir_path = "temp_test_dir_insert_key";
+        fs::create_dir_all(temp_dir_path).expect("Failed to create temp dir");
+        let mut sst_storage:SStStorage<File> = SStStorage::open(Path::new(&temp_dir_path)).expect("Failed to open SStStorage");
 
         let key = b"my_key".to_vec();
         let value = b"my_value".to_vec();
@@ -50,16 +47,15 @@ mod tests {
         assert_eq!(read_value, Some(value));
 
         // cleanup
-        fs::remove_file(temp_file_path).expect("Failed to remove temp file");
+        fs::remove_dir_all(temp_dir_path).expect("Failed to remove temp file");
     }
 
     #[test]
     fn test_insert_key_and_read_non_existing_key() {
         // Create a temporary file for testing
-        let temp_file_path = "temp_test_file_insert_delete_non_existing.txt";
-        let _ = fs::remove_file(temp_file_path);
-        let file = open_file_read_write(temp_file_path).expect("Failed to create temp file");
-        let mut sst_storage = SStStorage::new(file, 0, std::path::PathBuf::from(temp_file_path));
+        let temp_dir_path = "temp_test_dir_insert_non_existing_key";
+        fs::create_dir_all(temp_dir_path).expect("Failed to create temp dir");
+        let mut sst_storage:SStStorage<File> = SStStorage::open(Path::new(&temp_dir_path)).expect("Failed to open SStStorage");
 
         let key = b"my_key".to_vec();
         let value = b"my_value".to_vec();
@@ -73,16 +69,15 @@ mod tests {
         assert_eq!(read_value, None);
 
         // cleanup
-        fs::remove_file(temp_file_path).expect("Failed to remove temp file");
+        fs::remove_dir_all(temp_dir_path).expect("Failed to remove temp file");
     }
 
     #[test]
     fn test_update_existing_key() {
         // Create a temporary file for testing
-        let temp_file_path = "temp_test_file_update_key.txt";
-        let _ = fs::remove_file(temp_file_path);
-        let file = open_file_read_write(temp_file_path).expect("Failed to create temp file");
-        let mut sst_storage = SStStorage::new(file, 0, std::path::PathBuf::from(temp_file_path));
+        let temp_dir_path = "temp_test_dir_update_existing_key";
+        fs::create_dir_all(temp_dir_path).expect("Failed to create temp dir");
+        let mut sst_storage:SStStorage<File> = SStStorage::open(Path::new(&temp_dir_path)).expect("Failed to open SStStorage");
 
         // Insert a known kv pair to the file
         let key = b"my_key".to_vec();
@@ -102,16 +97,15 @@ mod tests {
         assert_eq!(read_value, Some(updated_value));
 
         // cleanup
-        fs::remove_file(temp_file_path).expect("Failed to remove temp file");
+        fs::remove_dir_all(temp_dir_path).expect("Failed to remove temp file");
     }
 
     #[test]
     fn test_delete_existing_key() {
         // Create a temporary file for testing
-        let temp_file_path = "temp_test_file_delete_existing.txt";
-        let _ = fs::remove_file(temp_file_path);
-        let file = open_file_read_write(temp_file_path).expect("Failed to create temp file");
-        let mut sst_storage = SStStorage::new(file, 0, std::path::PathBuf::from(temp_file_path));
+        let temp_dir_path = "temp_test_dir_delete_existing_key";
+        fs::create_dir_all(temp_dir_path).expect("Failed to create temp dir");
+        let mut sst_storage:SStStorage<File> = SStStorage::open(Path::new(&temp_dir_path)).expect("Failed to open SStStorage");
 
         // Insert a known kv pair to the file
         let key = b"my_key".to_vec();
@@ -131,22 +125,22 @@ mod tests {
 
         // Verify tombstone was persisted to disk
         // The file should have 2 records: original write + tombstone
+        let temp_file_path = format!("{}/0.log", temp_dir_path);
         let records = read_from_file(&temp_file_path).unwrap();
         assert_eq!(records.len(), 2, "Expected 2 records: original + tombstone");
         assert!(records[1].tombstone, "Second record should be a tombstone");
         assert_eq!(records[1].key, key, "Tombstone should have the same key");
 
         // cleanup
-        fs::remove_file(temp_file_path).expect("Failed to remove temp file");
+        fs::remove_dir_all(temp_dir_path).expect("Failed to remove temp file");
     }
 
     #[test]
     fn test_delete_non_existing_key() {
         // Create a temporary file for testing
-        let temp_file_path = "temp_test_file_delete_non_existing.txt";
-        let _ = fs::remove_file(temp_file_path);
-        let file = open_file_read_write(temp_file_path).expect("Failed to create temp file");
-        let mut sst_storage = SStStorage::new(file, 0, std::path::PathBuf::from(temp_file_path));
+        let temp_dir_path = "temp_test_dir_delete_non_existing_key";
+        fs::create_dir_all(temp_dir_path).expect("Failed to create temp dir");
+        let mut sst_storage:SStStorage<File> = SStStorage::open(Path::new(&temp_dir_path)).expect("Failed to open SStStorage");
 
         // Try to delete a key that was never inserted
         let non_existent_key = b"ghost_key".to_vec();
@@ -156,6 +150,7 @@ mod tests {
         assert!(result.is_ok(), "Deleting non-existent key should not error");
 
         // Verify no tombstone was written (file should be empty)
+        let temp_file_path = format!("{}/0.log", temp_dir_path);
         let records = read_from_file(&temp_file_path).unwrap();
         assert_eq!(
             records.len(),
@@ -164,7 +159,7 @@ mod tests {
         );
 
         // cleanup
-        fs::remove_file(temp_file_path).expect("Failed to remove temp file");
+        fs::remove_dir_all(temp_dir_path).expect("Failed to remove temp file");
     }
 
 }


### PR DESCRIPTION
## Summary

- **Removed custom `FileIO` trait** in favor of using Rust's standard `Read + Write + Seek` traits
- **Added `Storage` trait** with `open()` method for file initialization
- **Added `file_id` to `IndexEntry`** to support multi-file BitCask storage
- **Implemented `SStStorage::open()`** that scans directories for `.log` files
- **Added `rotate_file()`** method for automatic file rotation when max size (1MB) is reached
- **Updated all tests** to use directory-based initialization

## Known Issues

This PR contains foundational work but has several known bugs that will be tracked as separate issues:

- [ ] `load_db_from_disk` only loads from active file, not all files
- [ ] `read()` opens new file handle per read operation (inefficient)
- [ ] Debug `println!` left in `read()` function
- [ ] Race condition in file rotation logic
- [ ] `rotate_file` hardcodes path format
- [ ] `cleanup_expired_keys` doesn't persist tombstones (pre-existing bug)

## Test Plan

- [x] All existing tests pass
- [ ] Manual testing of file rotation
- [ ] Test multi-file read after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)