### PR TITLE
Implemented merge compaction for bitcask

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -281,7 +281,7 @@ fn delete_key(
     // First, check if the key exists in the live index.
     // If it does, we will write a tombstone record to the log and remove it from the index.
     if keydir.index.contains_key(key) {
-        write_to_file(key, &[], true, Some(0), keydir, storage)?;
+        write_to_file(key, &[], true, Some(Utc::now().timestamp() as u64), keydir, storage)?;
         keydir.index.remove(key);
         Ok(())
     } else {
@@ -358,7 +358,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     key.trim().as_bytes(),
                     value.trim().as_bytes(),
                     false,
-                    Some(generate_timestamp_one_hour_in_future()),
+                    Some(Utc::now().timestamp() as u64),
                     &mut key_dir,
                     &mut file_storage,
                 )?;
@@ -391,7 +391,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     key.trim().as_bytes(),
                     value.trim().as_bytes(),
                     false,
-                    Some(generate_timestamp_one_hour_in_future()),
+                    Some(Utc::now().timestamp() as u64),
                     &mut key_dir,
                     &mut file_storage,
                 )?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ struct IndexEntry {
     offset: u64,
     length: u64,
     timestamp: Option<u64>,
+    tombstone: bool
 }
 
 struct FileStorage<T: Read + Write + Seek> {
@@ -25,7 +26,7 @@ struct FileStorage<T: Read + Write + Seek> {
     dir_path: PathBuf,
 }
 
-const MAX_LOG_FILE_SIZE: u64 = 1024 * 1 * 1; // 2KB for testing, can be increased to 64MB in production
+const MAX_LOG_FILE_SIZE: u64 = 128 * 1 * 1; // 2KB for testing, can be increased to 64MB in production
 
 impl FileStorage<File> {
     fn open(dir: &Path) -> io::Result<Self> {
@@ -106,6 +107,7 @@ impl FileStorage<File> {
                     offset: current_offset,
                     length: buffer.len() as u64,
                     timestamp: *timestamp,
+                    tombstone: false
                 }),
             );
         }
@@ -177,16 +179,19 @@ fn load_db_from_disk<T: Read + Write + Seek>(
                         }
                     };
                     let record_len = after - before;
-                    if keyvalue.tombstone {
-                        keydir.index.remove(&keyvalue.key);
-                    } else {
+                    let should_insert =  match keydir.index.get(&keyvalue.key) {
+                        None => true,
+                        Some(existing) => keyvalue.timestamp > existing.timestamp
+                    };
+                    if should_insert {
                         keydir.index.insert(
                             keyvalue.key,
                             IndexEntry {
-                                file_id: file_id,
+                                file_id,
                                 offset: current_offset,
                                 length: record_len,
                                 timestamp: keyvalue.timestamp,
+                                tombstone: keyvalue.tombstone
                             },
                         );
                     }
@@ -204,6 +209,7 @@ fn load_db_from_disk<T: Read + Write + Seek>(
             }
         }
     }
+    keydir.index.retain(|_key, entry| !entry.tombstone);
     Ok(())
 }
 
@@ -246,6 +252,7 @@ fn write_to_file(
                 offset,
                 length,
                 timestamp,
+                tombstone: mark_as_deleted
             },
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,12 +56,70 @@ impl FileStorage<File> {
     }
 
     fn rotate_log_file(&mut self) -> io::Result<()> {
-        self.active_file_id += 1;
+        self.active_file_id = self.next_file_id();
         let path = self.dir_path.join(format!("{}.log", self.active_file_id));
         let file = open_file_read_write(&path)?;
         self.file_handles.insert(self.active_file_id, file);
         Ok(())
     }
+
+    
+    fn merge(&mut self, index: &HashMap<Vec<u8>, IndexEntry>) 
+    -> Result<Vec<(Vec<u8>, IndexEntry)>, Error> {
+        let mut index_updates: Vec<(Vec<u8>, IndexEntry)> = Vec::new();
+        let closed_file_ids: Vec<u64> = self.file_handles.keys().copied().filter(|id| *id != self.active_file_id).collect();
+        println!("Closed file ids: {:?}", closed_file_ids);
+
+        // Opening a new file for merge process to write these older files keys.
+        let merge_file_id = self.next_file_id();
+        let path = self.dir_path.join(format!("{}.log", merge_file_id));
+        let file = open_file_read_write(&path)?;
+        self.file_handles.insert(merge_file_id, file);
+
+        let mut records: Vec<(Vec<u8>, Vec<u8>, Option<u64>)> = Vec::new();
+
+        for (key, entry) in index {
+            // Key is &Vec<u8> , entry is &IndexEntry
+            if !closed_file_ids.contains(&entry.file_id) {
+                continue;
+            }
+            let file_handle =  self.file_handles.get_mut(&entry.file_id).unwrap();
+            let mut buffer = vec![0; entry.length as usize];
+            file_handle.seek(io::SeekFrom::Start(entry.offset))?;
+            file_handle.read_exact(&mut buffer)?;
+            records.push((key.clone(), buffer, entry.timestamp));
+        }
+
+        let merge_file_handle =  self.file_handles.get_mut(&merge_file_id).unwrap();
+        for (key, buffer, timestamp) in &records {
+            let current_offset = match merge_file_handle.stream_position() {
+                Ok(pos) => pos,
+                Err(e) => {
+                    eprintln!("Error getting stream position before reading: {}", e);
+                    return Err(e);
+                }
+            };
+            merge_file_handle.write_all(buffer)?;
+            index_updates.push((key.to_vec(),
+                IndexEntry {
+                    file_id: merge_file_id,
+                    offset: current_offset,
+                    length: buffer.len() as u64,
+                    timestamp: *timestamp,
+                }),
+            );
+        }
+        Ok(index_updates)
+    }
+
+    fn next_file_id(&self) -> u64 {
+        let max_id = match self.file_handles.keys().max() {
+            Some(id) => id + 1,
+            None => 0,
+        };
+        max_id
+    }
+
 }
 
 struct KeyDir {
@@ -302,14 +360,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 println!("Read key!");
                 let mut key = String::new();
                 let _ = io::stdin().read_line(&mut key);
-                if let Some(value) =
-                    read_from_file(key.trim().as_bytes(), &key_dir, &mut file_storage)?
-                {
+                let key_bytes = key.trim().as_bytes();
+                if let Some(entry) = key_dir.index.get(key_bytes) {
+                    println!("Reading from file_id: {}, offset: {}", entry.file_id, entry.offset);
+                }
+                if let Some(value) = read_from_file(key_bytes, &key_dir, &mut file_storage)? {
                     println!("Value: {:?}", String::from_utf8_lossy(&value));
                 } else {
                     println!(
                         "Key not found: {:?}",
-                        String::from_utf8_lossy(key.trim().as_bytes())
+                        String::from_utf8_lossy(key_bytes)
                     );
                 }
             }
@@ -337,6 +397,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 // Remove the newline character from the input
                 let key = key.trim();
                 delete_key(key.as_bytes(), &mut key_dir, &mut file_storage)?;
+            }
+            5 => {
+                let updates = file_storage.merge(&key_dir.index)?;
+                println!("Merge completed. Updated {} keys:", updates.len());
+                for (key, entry) in &updates {
+                    println!("  Key: {:?} -> file_id: {}, offset: {}", 
+                        String::from_utf8_lossy(key), entry.file_id, entry.offset);
+                }
+                // Apply updates to key_dir
+                for (key, entry) in updates {
+                    key_dir.index.insert(key, entry);
+                }
             }
             /*
             5 => {
@@ -393,7 +465,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             9 => {
                 let _ = test_corruption();
             }*/
-            4_u32..=u32::MAX => todo!(),
+            5_u32..=u32::MAX => todo!(),
         }
     }
     Ok(())

--- a/src/main_test.rs
+++ b/src/main_test.rs
@@ -2,7 +2,7 @@
 mod tests {
     use std::{collections::HashMap, fs, path::PathBuf};
 
-    use crate::{FileStorage, KeyDir, delete_key, read_from_file, update_key_value, write_to_file, dance_of_bytes::read_from_file as read_from_file_dance_of_bytes};
+    use crate::{FileStorage, KeyDir, dance_of_bytes::read_from_file as read_from_file_dance_of_bytes, delete_key, load_db_from_disk, read_from_file, update_key_value, write_to_file};
     #[test]
     fn test_write() {
         // Create a temporary file for testing
@@ -193,6 +193,90 @@ mod tests {
         assert!(result.is_ok(), "Deleting a non-existing key should not error");
 
         // Clean up the temporary file
+        fs::remove_dir_all(temp_file_dir).expect("Failed to remove temp file");
+    }
+
+    #[test]
+    fn test_merge_then_restart_keeps_latest_value() {
+        // Create a temporary file for testing
+        let temp_file_dir = "temp_test_merge_then_restart_keeps_latest_value";
+        // Clean up any existing file from previous test runs
+        let _ = fs::remove_dir_all(temp_file_dir);
+        let _ = fs::create_dir(temp_file_dir);
+        let temp_file = PathBuf::from(temp_file_dir);
+
+        let key = b"my_key";
+        let value = b"old_value";
+        let timestamp = Some(1);
+        
+        // --- session 1: write old value, rotate, merge, then write new value ---
+        {
+            let mut file_storage = FileStorage::open(&temp_file).unwrap();
+            let mut key_dir = KeyDir {
+                index: HashMap::new(),
+            };
+
+            // Writing first value, small timestamp
+            write_to_file(key, value, false, timestamp, &mut key_dir, &mut file_storage).unwrap();
+
+            // close the active file so merge has something to read
+            file_storage.rotate_log_file().unwrap();
+
+            // merge the closed file, apply returned update to the keydir
+            let updates = file_storage.merge(&key_dir.index).unwrap();
+            for (key, entry) in updates {
+                key_dir.index.insert(key, entry);
+            }
+            
+            // newer value, larger timestamp -> goes to the active file
+            write_to_file(key, b"new_value", false, Some(2), &mut key_dir, &mut file_storage).unwrap();
+        }
+        // --- fake restart: fresh keydir + storage, rebuild from disk ---
+        let mut file_storage = FileStorage::open(&temp_file).unwrap();
+        let mut key_dir = KeyDir { index: HashMap::new() };
+        load_db_from_disk(&mut key_dir, &mut file_storage).unwrap();
+
+        // --- the value must be the newest one, not the resurrected old one ---
+        let value = read_from_file(key, &key_dir, &mut file_storage).unwrap();
+        assert_eq!(value, Some(b"new_value".to_vec()));
+
+        fs::remove_dir_all(temp_file_dir).expect("Failed to remove temp file");
+        
+    }
+
+    #[test]
+    fn test_tomsbtone_stays_deleted() {
+        // Create a temporary file for testing
+        let temp_file_dir = "temp_test_tombstone_stays_deleted";
+        // Clean up any existing file from previous test runs
+        let _ = fs::remove_dir_all(temp_file_dir);
+        let _ = fs::create_dir(temp_file_dir);
+        let temp_file = PathBuf::from(temp_file_dir);
+
+        let key = b"my_key";
+        
+        // --- session 1: write value, rotate, merge, then delete key ---
+        {
+            let mut file_storage = FileStorage::open(&temp_file).unwrap();
+            let mut key_dir = KeyDir {
+                index: HashMap::new(),
+            };
+
+            // Writing first value, small timestamp
+            write_to_file(key, b"value", false, Some(1), &mut key_dir, &mut file_storage).unwrap();
+
+            // delete the key -> tombstone goes to the active file
+            delete_key(key, &mut key_dir, &mut file_storage).unwrap();
+        }
+        // --- fake restart: fresh keydir + storage, rebuild from disk ---
+        let mut file_storage = FileStorage::open(&temp_file).unwrap();
+        let mut key_dir = KeyDir { index: HashMap::new() };
+        load_db_from_disk(&mut key_dir, &mut file_storage).unwrap();
+
+        // --- the value must be None since the tombstone should stay ---
+        let value = read_from_file(key, &key_dir, &mut file_storage).unwrap();
+        assert_eq!(value, None);
+
         fs::remove_dir_all(temp_file_dir).expect("Failed to remove temp file");
     }
 


### PR DESCRIPTION
Title: Add merge/compaction to reclaim disk space from stale records

Description: Implements log compaction (merge) to remove tombstones and old record versions that accumulate in closed log files.

Key changes:

Added FileStorage::merge() method — fully decoupled from KeyDir, takes index map as input, returns update vector for caller to apply
Two-phase implementation: (1) buffer live records from closed files in memory, (2) write to new merge output file — avoids borrow checker issues from simultaneous read/write handles
Safe file ID allocation: new next_file_id() helper ensures merge output and rotation never collide by using actual highest ID + 1
Returns Vec<(key, IndexEntry)> for caller to apply to keydir, keeping FileStorage decoupled from keydir mutation
Design decisions:

Manual trigger only (CLI menu option 5) — background merge planned as follow-up
Blocking (synchronous) — simplifies implementation, background threading next
Returns updates rather than mutating keydir directly — supports future concurrent merge under read locks
Testing:

Manual testing confirms keys relocate to new file IDs post-merge
Unit tests for merge behavior (WIP)
Follow-up work:

Delete old files after merge (currently merge output created but originals remain)
Hint file generation during merge
Read hint files on startup for fast keydir rebuild